### PR TITLE
[#104] Define Proposal domain models in Prisma schema

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -39,7 +39,8 @@ model Organization {
   updatedAt DateTime @updatedAt
 
   // Relations
-  users User[]
+  users     User[]
+  proposals Proposal[]
 
   @@map("organizations")
 }
@@ -112,9 +113,101 @@ enum UserStatus {
 }
 
 // ==========================================
+// PROPOSAL DOMAIN - Issue #104
+// ==========================================
+
+/// Proposal model - Represents an RFP/RFQ response proposal
+/// Organized hierarchically: Proposal → Section → Question → Response
+model Proposal {
+  id        String  @id @default(uuid()) @db.Uuid
+  title     String  @db.VarChar(500)
+  rfpNumber String? @db.VarChar(100)
+  status    String  @default("draft") @db.VarChar(50)
+
+  // Multi-tenancy
+  organizationId String       @db.Uuid
+  organization   Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  // Relations
+  sections ProposalSection[]
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([organizationId])
+  @@index([status])
+  @@map("proposals")
+}
+
+/// ProposalSection model - Logical sections within a proposal
+/// Maps to RFP document structure (e.g., "Technical Approach", "Past Performance")
+model ProposalSection {
+  id    String @id @default(uuid()) @db.Uuid
+  title String @db.VarChar(500)
+  order Int // Determines display order within proposal
+
+  // Hierarchy
+  proposalId String   @db.Uuid
+  proposal   Proposal @relation(fields: [proposalId], references: [id], onDelete: Cascade)
+
+  // Relations
+  questions Question[]
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([proposalId])
+  @@map("proposal_sections")
+}
+
+/// Question model - Individual RFP questions/requirements
+/// Extracted from RFP documents via VLM processing
+model Question {
+  id    String @id @default(uuid()) @db.Uuid
+  text  String @db.Text
+  order Int // Determines display order within section
+
+  // Hierarchy
+  sectionId String          @db.Uuid
+  section   ProposalSection @relation(fields: [sectionId], references: [id], onDelete: Cascade)
+
+  // Relations
+  responses Response[]
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([sectionId])
+  @@map("questions")
+}
+
+/// Response model - AI-generated or human-written answers to questions
+/// Includes trust scoring and versioning support
+model Response {
+  id         String @id @default(uuid()) @db.Uuid
+  content    String @db.Text
+  trustScore Float? // AI trust score (0.0 - 1.0)
+  status     String @default("draft") @db.VarChar(50)
+
+  // Hierarchy
+  questionId String   @db.Uuid
+  question   Question @relation(fields: [questionId], references: [id], onDelete: Cascade)
+
+  // Metadata
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([questionId])
+  @@index([status])
+  @@map("responses")
+}
+
+// ==========================================
 // PLACEHOLDER MODELS (TO BE REPLACED)
 // ==========================================
-// Proposal models (Proposal, Section, Question, Response) - Issue #104
 // Knowledge models (Document, Chunk, LibraryEntry) - Issue #105
 // Indexes and pgvector configuration - Issue #106
 


### PR DESCRIPTION
## Context
Implementa a sub-tarefa [#104](https://github.com/tjsasakifln/sentinel-rfp/issues/104) do parent issue [#19](https://github.com/tjsasakifln/sentinel-rfp/issues/19) (Prisma Schema Design).

Esta PR define os modelos Prisma para o domínio Proposal, estabelecendo a estrutura hierárquica core para gerenciamento de RFP responses.

## Changes

### Modelos Adicionados

#### 1. **Proposal** (Root Entity)
- Representa um RFP/RFQ response proposal
- Multi-tenancy via `organizationId` (FK para Organization)
- Campos: `title`, `rfpNumber`, `status`
- Indexes: `organizationId`, `status`

#### 2. **ProposalSection** (Hierarchical Sections)
- Seções lógicas dentro de um proposal
- Mapeia estrutura do RFP (ex: "Technical Approach", "Past Performance")
- Campo `order` para ordenação sequencial
- Cascade delete: Proposal → Section

#### 3. **Question** (RFP Questions/Requirements)
- Questões individuais extraídas de RFPs via VLM
- Campo `text` (TEXT) para questões longas
- Campo `order` para ordenação dentro da section
- Cascade delete: Section → Question

#### 4. **Response** (AI-Generated or Human Answers)
- Respostas geradas por IA ou escritas por humanos
- **Trust Score** (`Float?`): 0.0-1.0 range
- Campo `status` para workflow tracking
- Cascade delete: Question → Response

### Hierarquia Completa
```
Organization
  ↓ (1:N)
Proposal
  ↓ (1:N)
ProposalSection
  ↓ (1:N)
Question
  ↓ (1:N)
Response
```

### Mudanças Adicionais
- Adicionada relação `proposals` em `Organization` model

## Testing

- ✅ `prisma format`: Schema formatado com sucesso
- ✅ `prisma validate`: Schema válido (sem erros)
- ✅ `prisma generate`: Prisma Client gerado com sucesso
- ✅ `npm run typecheck`: TypeScript sem erros

## Acceptance Criteria (9/9 ✅)

- ✅ Model Proposal definido
- ✅ Model ProposalSection definido
- ✅ Model Question definido
- ✅ Model Response definido
- ✅ Relações hierárquicas: Proposal → Section → Question → Response
- ✅ Relação com Organization (multi-tenancy)
- ✅ Campos de ordenação (order)
- ✅ Campos de status e trustScore
- ✅ Validação via `prisma format` e `prisma validate`

## Risks

**Baixo risco**

- Schema changes only, sem alteração de runtime
- Validação Prisma OK
- TypeScript compilation OK
- Estrutura alinhada com DATA_ARCHITECTURE.md

## Rollback Plan

Se necessário:
```bash
git revert fb9a373
git push origin main
```

## Next Steps

Após merge desta PR:

- [ ] #105 - Definir modelos de Knowledge (Document, Chunk, LibraryEntry)
- [ ] #106 - Configurar pgvector extension e indexes
- [ ] #107 - Criar seed script com dados de teste
- [ ] #108 - Criar migration inicial e validar schema completo

## References

- Parent Issue: [#19 - Prisma Schema Design](https://github.com/tjsasakifln/sentinel-rfp/issues/19)
- DATA_ARCHITECTURE.md: Proposal domain
- PRD.md: Proposal workflows
- ROADMAP.md: Milestone 1.2 (Database & Auth)

## Closes

Closes #104