### PR TITLE
[#113] Implement logout endpoint with token blacklisting

### DIFF
--- a/apps/api/src/identity/auth/auth.controller.ts
+++ b/apps/api/src/identity/auth/auth.controller.ts
@@ -10,9 +10,11 @@
 import {
   Body,
   Controller,
+  Headers,
   HttpCode,
   HttpStatus,
   Post,
+  UnauthorizedException,
   ValidationPipe,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
@@ -21,6 +23,7 @@ import { AuthService } from './auth.service';
 import { Public } from './decorators/public.decorator';
 import { AuthResponseDto } from './dto/auth-response.dto';
 import { LoginDto } from './dto/login.dto';
+import { LogoutDto } from './dto/logout.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
 
@@ -117,5 +120,49 @@ export class AuthController {
     dto: RefreshDto,
   ): Promise<AuthResponseDto> {
     return this.authService.refresh(dto);
+  }
+
+  /**
+   * POST /v1/auth/logout - Logout user
+   *
+   * Protected endpoint (requires authentication).
+   * Invalidates both access and refresh tokens via blacklisting.
+   *
+   * Rate Limiting: 10 requests per minute per IP
+   *
+   * Security - Token Blacklisting:
+   * - Extracts access token from Authorization header
+   * - Extracts refresh token from request body
+   * - Both tokens are added to blacklist with appropriate TTL
+   * - Tokens remain blacklisted until their natural expiration
+   * - Prevents token reuse after logout
+   *
+   * Implementation Note:
+   * - Currently uses in-memory blacklist (single instance)
+   * - TODO: Migrate to Redis for distributed blacklist (#120)
+   *
+   * @param authorization - Authorization header with Bearer token
+   * @param dto - Logout data containing refresh token
+   * @returns 204 No Content
+   * @throws UnauthorizedException if tokens invalid (401)
+   * @throws BadRequestException if validation fails (400)
+   * @throws ThrottlerException if rate limit exceeded (429)
+   */
+  @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 req/min
+  @Post('logout')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async logout(
+    @Headers('authorization') authorization: string,
+    @Body(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+    dto: LogoutDto,
+  ): Promise<void> {
+    // Extract access token from Authorization header
+    if (!authorization || !authorization.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Authorization header missing or invalid');
+    }
+
+    const accessToken = authorization.substring(7); // Remove 'Bearer ' prefix
+
+    return this.authService.logout(accessToken, dto);
   }
 }

--- a/apps/api/src/identity/auth/auth.module.ts
+++ b/apps/api/src/identity/auth/auth.module.ts
@@ -21,6 +21,7 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { TokenBlacklistService } from './token-blacklist.service';
 
 @Module({
   imports: [
@@ -72,7 +73,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, TokenBlacklistService],
   exports: [JwtModule, PassportModule, AuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/identity/auth/auth.service.ts
+++ b/apps/api/src/identity/auth/auth.service.ts
@@ -22,46 +22,21 @@ const prisma = new PrismaClient();
 
 import { AuthResponseDto } from './dto/auth-response.dto';
 import { LoginDto } from './dto/login.dto';
+import { LogoutDto } from './dto/logout.dto';
 import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
 import { JwtPayload } from './strategies/jwt.strategy';
+import { TokenBlacklistService } from './token-blacklist.service';
 import { hashPassword, verifyPassword } from './utils/password.util';
 
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
 
-  /**
-   * In-memory blacklist for refresh tokens
-   * TODO: Replace with Redis in production (#120)
-   * Map<tokenId, expirationTimestamp>
-   */
-  private readonly tokenBlacklist = new Map<string, number>();
-
-  constructor(private readonly jwtService: JwtService) {
-    // Clean up expired tokens every hour
-    setInterval(() => this.cleanupBlacklist(), 60 * 60 * 1000);
-  }
-
-  /**
-   * Remove expired tokens from blacklist
-   * Called automatically every hour to prevent memory leaks
-   */
-  private cleanupBlacklist(): void {
-    const now = Date.now();
-    let removed = 0;
-
-    for (const [tokenId, expiration] of this.tokenBlacklist.entries()) {
-      if (expiration < now) {
-        this.tokenBlacklist.delete(tokenId);
-        removed++;
-      }
-    }
-
-    if (removed > 0) {
-      this.logger.log(`Cleaned up ${removed} expired tokens from blacklist`);
-    }
-  }
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly tokenBlacklist: TokenBlacklistService,
+  ) {}
 
   /**
    * Register a new user
@@ -381,7 +356,7 @@ export class AuthService {
       );
 
       // Check if token is blacklisted (already used)
-      if (this.tokenBlacklist.has(refreshToken)) {
+      if (this.tokenBlacklist.isBlacklisted(refreshToken)) {
         this.logger.warn(
           `Attempted reuse of blacklisted refresh token by user ${payload.email}`,
         );
@@ -390,10 +365,10 @@ export class AuthService {
 
       // Blacklist the old refresh token (7 days = 604800000 ms)
       const expirationTime = Date.now() + 7 * 24 * 60 * 60 * 1000;
-      this.tokenBlacklist.set(refreshToken, expirationTime);
+      this.tokenBlacklist.addToBlacklist(refreshToken, expirationTime);
 
       this.logger.log(
-        `Blacklisted refresh token for user ${payload.email}. Blacklist size: ${this.tokenBlacklist.size}`,
+        `Blacklisted refresh token for user ${payload.email}. Blacklist size: ${this.tokenBlacklist.getBlacklistSize()}`,
       );
 
       // Fetch fresh user data from database
@@ -472,6 +447,84 @@ export class AuthService {
         error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(`Refresh token verification failed: ${errorMessage}`);
       throw new UnauthorizedException('Invalid refresh token');
+    }
+  }
+
+  /**
+   * Logout user by blacklisting both access and refresh tokens
+   *
+   * Flow:
+   * 1. Extract access token from Authorization header
+   * 2. Extract refresh token from request body
+   * 3. Decode both tokens to get expiration times
+   * 4. Blacklist both tokens with appropriate TTL
+   * 5. Return 204 No Content
+   *
+   * Security - Token Blacklisting:
+   * - Both access and refresh tokens are invalidated
+   * - Tokens are blacklisted until their natural expiration
+   * - TTL is calculated based on remaining time until expiration
+   * - Prevents token reuse after logout
+   * - JwtAuthGuard checks blacklist before allowing access
+   *
+   * Implementation Note:
+   * - Currently uses in-memory blacklist (single instance)
+   * - TODO: Migrate to Redis for distributed blacklist (#120)
+   *
+   * @param accessToken - Access token from Authorization header
+   * @param dto - Logout data containing refresh token
+   * @throws UnauthorizedException if tokens are invalid
+   */
+  async logout(accessToken: string, dto: LogoutDto): Promise<void> {
+    const { refreshToken } = dto;
+
+    try {
+      // Decode access token to get expiration
+      const accessPayload = this.jwtService.decode(accessToken) as JwtPayload & { exp: number };
+      if (!accessPayload || !accessPayload.exp) {
+        throw new UnauthorizedException('Invalid access token');
+      }
+
+      // Decode refresh token to get expiration
+      const refreshPayload = this.jwtService.decode(refreshToken) as JwtPayload & { exp: number };
+      if (!refreshPayload || !refreshPayload.exp) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
+      this.logger.log(
+        `Logout request for user: ${accessPayload.email} (${accessPayload.sub})`,
+      );
+
+      const now = Math.floor(Date.now() / 1000); // Unix timestamp in seconds
+
+      // Blacklist access token (remaining TTL in milliseconds)
+      const accessTtl = accessPayload.exp - now;
+      if (accessTtl > 0) {
+        const accessExpirationTime = Date.now() + accessTtl * 1000;
+        this.tokenBlacklist.addToBlacklist(accessToken, accessExpirationTime);
+        this.logger.log(
+          `Blacklisted access token for user ${accessPayload.email}. TTL: ${accessTtl}s`,
+        );
+      }
+
+      // Blacklist refresh token (remaining TTL in milliseconds)
+      const refreshTtl = refreshPayload.exp - now;
+      if (refreshTtl > 0) {
+        const refreshExpirationTime = Date.now() + refreshTtl * 1000;
+        this.tokenBlacklist.addToBlacklist(refreshToken, refreshExpirationTime);
+        this.logger.log(
+          `Blacklisted refresh token for user ${accessPayload.email}. TTL: ${refreshTtl}s`,
+        );
+      }
+
+      this.logger.log(
+        `Logout successful for user ${accessPayload.email}. Blacklist size: ${this.tokenBlacklist.getBlacklistSize()}`,
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      this.logger.warn(`Logout failed: ${errorMessage}`);
+      throw new UnauthorizedException('Logout failed');
     }
   }
 }

--- a/apps/api/src/identity/auth/dto/logout.dto.ts
+++ b/apps/api/src/identity/auth/dto/logout.dto.ts
@@ -1,0 +1,26 @@
+/**
+ * Logout DTO - Token invalidation request
+ *
+ * Used to invalidate both access and refresh tokens.
+ * Implements token blacklisting for secure logout.
+ *
+ * Security Notes:
+ * - Both access and refresh tokens are blacklisted
+ * - Tokens remain blacklisted until their natural expiration
+ * - TTL is calculated based on remaining time until expiration
+ * - Prevents token reuse after logout
+ *
+ * @module LogoutDto
+ */
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class LogoutDto {
+  /**
+   * Refresh token to invalidate
+   * Must be a valid JWT
+   */
+  @IsString({ message: 'Refresh token must be a string' })
+  @IsNotEmpty({ message: 'Refresh token is required' })
+  refreshToken!: string;
+}

--- a/apps/api/src/identity/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/identity/auth/strategies/jwt.strategy.ts
@@ -10,7 +10,10 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
+import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+
+import { TokenBlacklistService } from '../token-blacklist.service';
 
 /**
  * JWT Payload Interface
@@ -48,7 +51,10 @@ export interface AuthenticatedUser {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private readonly tokenBlacklist: TokenBlacklistService,
+  ) {
     const publicKey = configService.get<string>('JWT_PUBLIC_KEY');
 
     if (!publicKey) {
@@ -64,6 +70,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
       algorithms: ['RS256'],
       issuer: 'sentinel-rfp',
       audience: 'sentinel-rfp-api',
+      passReqToCallback: true, // Pass request to validate method
     });
   }
 
@@ -73,20 +80,37 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
    * Called automatically by Passport after token is verified.
    * Return value is attached to request.user
    *
+   * Security Checks:
+   * - Validates required fields in payload
+   * - Checks if token is blacklisted (logout or refresh rotation)
+   *
+   * @param req - Express request object
    * @param payload - Decoded JWT payload
    * @returns AuthenticatedUser object
-   * @throws UnauthorizedException if payload is invalid
+   * @throws UnauthorizedException if payload is invalid or token is blacklisted
    */
-  async validate(payload: JwtPayload): Promise<AuthenticatedUser> {
+  async validate(req: Request, payload: JwtPayload): Promise<AuthenticatedUser> {
     // Validate required fields
     if (!payload.sub || !payload.email || !payload.organizationId) {
       throw new UnauthorizedException('Invalid token payload');
     }
 
+    // Extract token from Authorization header
+    const authorization = req.headers.authorization;
+    if (!authorization || !authorization.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Authorization header missing or invalid');
+    }
+
+    const token = authorization.substring(7); // Remove 'Bearer ' prefix
+
+    // Check if token is blacklisted (logout or refresh rotation)
+    if (this.tokenBlacklist.isBlacklisted(token)) {
+      throw new UnauthorizedException('Token has been invalidated');
+    }
+
     // Additional validation can be added here:
     // - Check if user still exists in database
     // - Check if user is active
-    // - Check if token is blacklisted
     // - Check if organization is active
 
     // Return user object that will be attached to request

--- a/apps/api/src/identity/auth/token-blacklist.service.ts
+++ b/apps/api/src/identity/auth/token-blacklist.service.ts
@@ -1,0 +1,96 @@
+/**
+ * Token Blacklist Service
+ *
+ * Manages blacklisting of JWT tokens for logout and refresh token rotation.
+ * Shared between AuthService and JwtStrategy to prevent circular dependencies.
+ *
+ * Implementation:
+ * - Currently uses in-memory Map (single instance)
+ * - TODO: Migrate to Redis for distributed blacklist (#120)
+ * - Automatic cleanup of expired tokens every hour
+ *
+ * @module TokenBlacklistService
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class TokenBlacklistService {
+  private readonly logger = new Logger(TokenBlacklistService.name);
+
+  /**
+   * In-memory blacklist for tokens
+   * Map<token, expirationTimestamp>
+   */
+  private readonly blacklist = new Map<string, number>();
+
+  constructor() {
+    // Clean up expired tokens every hour
+    setInterval(() => this.cleanupBlacklist(), 60 * 60 * 1000);
+  }
+
+  /**
+   * Add token to blacklist with expiration time
+   *
+   * @param token - JWT token to blacklist
+   * @param expirationTime - Unix timestamp in milliseconds when token expires
+   */
+  addToBlacklist(token: string, expirationTime: number): void {
+    this.blacklist.set(token, expirationTime);
+  }
+
+  /**
+   * Check if token is blacklisted
+   *
+   * @param token - JWT token to check
+   * @returns true if token is blacklisted, false otherwise
+   */
+  isBlacklisted(token: string): boolean {
+    if (!this.blacklist.has(token)) {
+      return false;
+    }
+
+    // Check if token is still valid (not expired)
+    const expirationTime = this.blacklist.get(token)!;
+    const now = Date.now();
+
+    if (expirationTime < now) {
+      // Token expired, remove from blacklist
+      this.blacklist.delete(token);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Get blacklist size (for monitoring)
+   *
+   * @returns number of tokens in blacklist
+   */
+  getBlacklistSize(): number {
+    return this.blacklist.size;
+  }
+
+  /**
+   * Remove expired tokens from blacklist
+   * Called automatically every hour to prevent memory leaks
+   */
+  private cleanupBlacklist(): void {
+    const now = Date.now();
+    let removed = 0;
+
+    for (const [token, expiration] of this.blacklist.entries()) {
+      if (expiration < now) {
+        this.blacklist.delete(token);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      this.logger.log(
+        `Cleaned up ${removed} expired tokens from blacklist. Current size: ${this.blacklist.size}`,
+      );
+    }
+  }
+}

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -466,4 +466,215 @@ describe('Authentication (e2e)', () => {
       expect(response.body).toHaveProperty('message');
     }, 10000); // Longer timeout for rate limiting test
   });
+
+  describe('/api/v1/auth/logout (POST)', () => {
+    let testUser: {
+      email: string;
+      password: string;
+      accessToken: string;
+      refreshToken: string;
+    };
+
+    beforeAll(async () => {
+      // Create test user for logout tests
+      const timestamp = Date.now();
+      const email = `test+logout${timestamp}@example.com`;
+      const password = 'LogoutPass123!';
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/register')
+        .send({
+          email,
+          password,
+          firstName: 'Logout',
+          lastName: 'Test',
+          organizationName: `Logout Test Org ${timestamp}`,
+        });
+
+      testUser = {
+        email,
+        password,
+        accessToken: response.body.accessToken,
+        refreshToken: response.body.refreshToken,
+      };
+    });
+
+    it('should logout successfully with valid tokens', async () => {
+      const logoutDto = {
+        refreshToken: testUser.refreshToken,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${testUser.accessToken}`)
+        .send(logoutDto)
+        .expect(204);
+
+      // Should return no content
+      expect(response.body).toEqual({});
+    });
+
+    it('should reject access with blacklisted access token', async () => {
+      // Login to get new tokens
+      const loginResponse = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      const accessToken = loginResponse.body.accessToken;
+      const refreshToken = loginResponse.body.refreshToken;
+
+      // Logout to blacklist tokens
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ refreshToken })
+        .expect(204);
+
+      // Try to use blacklisted access token (should fail)
+      // This would be tested on a protected endpoint
+      // For now, we test that logging out again fails
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ refreshToken })
+        .expect(401);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('invalidated');
+    });
+
+    it('should reject refresh with blacklisted refresh token', async () => {
+      // Login to get new tokens
+      const loginResponse = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      const accessToken = loginResponse.body.accessToken;
+      const refreshToken = loginResponse.body.refreshToken;
+
+      // Logout to blacklist tokens
+      await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ refreshToken })
+        .expect(204);
+
+      // Try to refresh with blacklisted refresh token (should fail)
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/refresh')
+        .send({ refreshToken })
+        .expect(401);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('already used');
+    });
+
+    it('should reject logout without authorization header', async () => {
+      const logoutDto = {
+        refreshToken: testUser.refreshToken,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .send(logoutDto)
+        .expect(401);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('Authorization header');
+    });
+
+    it('should reject logout with invalid authorization header format', async () => {
+      const logoutDto = {
+        refreshToken: testUser.refreshToken,
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', 'InvalidFormat')
+        .send(logoutDto)
+        .expect(401);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('Authorization header');
+    });
+
+    it('should reject logout with missing refresh token', async () => {
+      // Login to get fresh access token
+      const loginResponse = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${loginResponse.body.accessToken}`)
+        .send({}) // Missing refreshToken
+        .expect(400);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('refreshToken');
+    });
+
+    it('should reject logout with invalid refresh token format', async () => {
+      // Login to get fresh access token
+      const loginResponse = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      const logoutDto = {
+        refreshToken: 'invalid-token-format',
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${loginResponse.body.accessToken}`)
+        .send(logoutDto)
+        .expect(401);
+
+      expect(response.body).toHaveProperty('message');
+      expect(response.body.message).toContain('Logout failed');
+    });
+
+    it('should handle rate limiting (10 req/min)', async () => {
+      // Login to get fresh tokens for rate limit test
+      const loginResponse = await request(app.getHttpServer())
+        .post('/api/v1/auth/login')
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        });
+
+      const logoutDto = {
+        refreshToken: loginResponse.body.refreshToken,
+      };
+
+      // Make 10 requests (should succeed on first, then fail with 401 for blacklisted token)
+      for (let i = 0; i < 10; i++) {
+        await request(app.getHttpServer())
+          .post('/api/v1/auth/logout')
+          .set('Authorization', `Bearer ${loginResponse.body.accessToken}`)
+          .send(logoutDto);
+      }
+
+      // 11th request should be rate limited
+      const response = await request(app.getHttpServer())
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${loginResponse.body.accessToken}`)
+        .send(logoutDto)
+        .expect(429);
+
+      expect(response.body).toHaveProperty('message');
+    }, 10000); // Longer timeout for rate limiting test
+  });
 });


### PR DESCRIPTION
## Context

Implementa o endpoint de logout com invalidação de tokens JWT via blacklisting, completando a sequência de autenticação do Milestone 1.2.

Issue parent: #21 - User Authentication (JWT)
Sub-issue: #113 - Implementar logout com token blacklisting

## Changes

### Core Implementation
- **LogoutDto**: DTO de validação para request de logout (refreshToken required)
- **TokenBlacklistService**: Serviço compartilhado para gerenciar blacklist de tokens (in-memory)
- **AuthService.logout()**: Método que blacklista access + refresh tokens com TTL correto
- **AuthController.logout**: Endpoint POST /v1/auth/logout protegido por JwtAuthGuard
- **JwtStrategy**: Modificado para verificar blacklist antes de autorizar requests

### Security Features
- Access e refresh tokens invalidados simultaneamente
- TTL calculado baseado no tempo restante até expiração natural
- JwtStrategy rejeita tokens blacklisted com 401 Unauthorized
- Rate limiting: 10 requests/minute no endpoint de logout
- Authorization header validation (Bearer token format)

### Testing
- 8 novos testes E2E para logout e blacklisting:
  - Logout com tokens válidos (sucesso)
  - Rejeição de access token blacklisted
  - Rejeição de refresh token blacklisted em /refresh
  - Validação de Authorization header
  - Validação de refresh token
  - Rate limiting

## Implementation Notes

**In-Memory Blacklist**: Atualmente usa Map<string, number> para blacklist. 
**TODO #120**: Migrar para Redis para suporte distributed/multi-instance.

**Cleanup**: TokenBlacklistService executa cleanup automático de tokens expirados a cada hora.

## Testing

```bash
# E2E tests (requer PostgreSQL rodando)
cd apps/api && npm run test:e2e -- --testPathPattern=auth

# Manual testing
# 1. Login
curl -X POST http://localhost:3000/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"user@example.com","password":"Password123!"}'

# 2. Logout
curl -X POST http://localhost:3000/api/v1/auth/logout \
  -H "Authorization: Bearer <access_token>" \
  -H "Content-Type: application/json" \
  -d '{"refreshToken":"<refresh_token>"}'

# 3. Try using blacklisted token (should fail with 401)
curl -X POST http://localhost:3000/api/v1/auth/logout \
  -H "Authorization: Bearer <blacklisted_access_token>" \
  -H "Content-Type: application/json" \
  -d '{"refreshToken":"<refresh_token>"}'
```

## Risks

**Single Instance Limitation**: In-memory blacklist não funciona em ambientes multi-instance. Solução temporária até migração para Redis (#120).

**Token Expiration**: Tokens blacklisted permanecem em memória até expiração natural. Cleanup automático previne memory leak.

## Rollback Plan

Se necessário reverter:
1. `git revert f25bf91` - Reverte o commit de logout
2. Endpoints de auth continuam funcionando (register, login, refresh não afetados)
3. Tokens existentes continuam válidos (sem blacklisting ativo)

## Closes

Closes #113