### PR TITLE
[#126] API Documentation com Swagger/OpenAPI

### DIFF
--- a/apps/api/src/identity/auth/auth.controller.ts
+++ b/apps/api/src/identity/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import {
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 
 import { AuthService } from './auth.service';
@@ -29,6 +30,7 @@ import { RefreshDto } from './dto/refresh.dto';
 import { RegisterDto } from './dto/register.dto';
 import { LoginAttemptsGuard } from './guards/login-attempts.guard';
 
+@ApiTags('identity')
 @Controller('v1/auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -48,6 +50,32 @@ export class AuthController {
    * @throws BadRequestException if validation fails (400)
    * @throws ThrottlerException if rate limit exceeded (429)
    */
+  @ApiOperation({
+    summary: 'Register new user',
+    description:
+      'Creates new user and optionally new organization. Returns JWT tokens and user info.',
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: 'User successfully registered',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.CONFLICT,
+    description: 'Email already exists',
+  })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: 'Organization ID not found',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Validation failed',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded (10 requests per minute)',
+  })
   @Public()
   @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 req/min
   @Post('register')
@@ -82,6 +110,28 @@ export class AuthController {
    * @throws ThrottlerException if IP rate limit exceeded (429)
    * @throws TooManyRequestsException if email-based limit exceeded (429)
    */
+  @ApiOperation({
+    summary: 'User login',
+    description:
+      'Validates credentials and returns JWT tokens. Dual-layer rate limiting prevents brute force attacks.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Login successful',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Invalid credentials',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Validation failed',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded (5 requests per minute or 5 failed attempts in 15 minutes)',
+  })
   @Public()
   @UseGuards(LoginAttemptsGuard)
   @Throttle({ default: { limit: 5, ttl: 60000 } }) // 5 req/min (stricter than register)
@@ -118,6 +168,28 @@ export class AuthController {
    * @throws BadRequestException if validation fails (400)
    * @throws ThrottlerException if rate limit exceeded (429)
    */
+  @ApiOperation({
+    summary: 'Refresh access token',
+    description:
+      'Exchanges refresh token for new access + refresh tokens. Implements refresh token rotation for security.',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Token refreshed successfully',
+    type: AuthResponseDto,
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Invalid, expired, or already used refresh token',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Validation failed',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded (20 requests per minute)',
+  })
   @Public()
   @Throttle({ default: { limit: 20, ttl: 60000 } }) // 20 req/min
   @Post('refresh')
@@ -155,6 +227,28 @@ export class AuthController {
    * @throws BadRequestException if validation fails (400)
    * @throws ThrottlerException if rate limit exceeded (429)
    */
+  @ApiOperation({
+    summary: 'Logout user',
+    description:
+      'Invalidates both access and refresh tokens via blacklisting. Prevents token reuse after logout.',
+  })
+  @ApiResponse({
+    status: HttpStatus.NO_CONTENT,
+    description: 'Logout successful',
+  })
+  @ApiResponse({
+    status: HttpStatus.UNAUTHORIZED,
+    description: 'Invalid tokens or missing authorization header',
+  })
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Validation failed',
+  })
+  @ApiResponse({
+    status: HttpStatus.TOO_MANY_REQUESTS,
+    description: 'Rate limit exceeded (10 requests per minute)',
+  })
+  @ApiBearerAuth()
   @Throttle({ default: { limit: 10, ttl: 60000 } }) // 10 req/min
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/apps/api/src/identity/auth/dto/auth-response.dto.ts
+++ b/apps/api/src/identity/auth/dto/auth-response.dto.ts
@@ -7,52 +7,78 @@
  * @module AuthResponseDto
  */
 
-export interface AuthResponseDto {
+import { ApiProperty } from '@nestjs/swagger';
+
+class UserDto {
+  @ApiProperty({
+    description: 'User UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    format: 'uuid',
+  })
+  id!: string;
+
+  @ApiProperty({
+    description: 'User email',
+    example: 'john.doe@example.com',
+    format: 'email',
+  })
+  email!: string;
+
+  @ApiProperty({
+    description: 'User full name (firstName + lastName)',
+    example: 'John Doe',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: 'User role within organization',
+    example: 'OWNER',
+    enum: ['OWNER', 'ADMIN', 'MEMBER', 'VIEWER'],
+  })
+  role!: string;
+
+  @ApiProperty({
+    description: 'Organization UUID',
+    example: '660e8400-e29b-41d4-a716-446655440001',
+    format: 'uuid',
+  })
+  organizationId!: string;
+
+  @ApiProperty({
+    description: 'Organization name',
+    example: 'Acme Corporation',
+  })
+  organizationName!: string;
+}
+
+export class AuthResponseDto {
   /**
    * JWT Access Token - Short-lived (15 minutes)
    * Used in Authorization header: Bearer <accessToken>
    */
-  accessToken: string;
+  @ApiProperty({
+    description: 'JWT Access Token (15-minute expiration)',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  accessToken!: string;
 
   /**
    * JWT Refresh Token - Long-lived (7 days)
    * Used to obtain new access tokens
    * Stored securely in httpOnly cookie (recommended) or client storage
    */
-  refreshToken: string;
+  @ApiProperty({
+    description: 'JWT Refresh Token (7-day expiration)',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  refreshToken!: string;
 
   /**
    * Sanitized user data (no sensitive fields like passwordHash)
    */
-  user: {
-    /**
-     * User UUID
-     */
-    id: string;
-
-    /**
-     * User email
-     */
-    email: string;
-
-    /**
-     * User full name (firstName + lastName)
-     */
-    name: string;
-
-    /**
-     * User role within organization
-     */
-    role: string;
-
-    /**
-     * Organization UUID
-     */
-    organizationId: string;
-
-    /**
-     * Organization name
-     */
-    organizationName: string;
-  };
+  @ApiProperty({
+    description: 'Sanitized user data (no sensitive fields)',
+    type: UserDto,
+  })
+  user!: UserDto;
 }

--- a/apps/api/src/identity/auth/dto/login.dto.ts
+++ b/apps/api/src/identity/auth/dto/login.dto.ts
@@ -12,6 +12,7 @@
  * @module LoginDto
  */
 
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
 export class LoginDto {
@@ -19,6 +20,12 @@ export class LoginDto {
    * User email - Used to identify the user
    * Format validation via IsEmail
    */
+  @ApiProperty({
+    description: 'User email address',
+    example: 'john.doe@example.com',
+    format: 'email',
+    maxLength: 255,
+  })
   @IsEmail({}, { message: 'Invalid email format' })
   @MaxLength(255, { message: 'Email must not exceed 255 characters' })
   email!: string;
@@ -29,6 +36,12 @@ export class LoginDto {
    * Note: Password strength validation is NOT enforced at login
    * (only at registration) to allow users with legacy passwords to login.
    */
+  @ApiProperty({
+    description: 'User password',
+    example: 'SecurePass123!',
+    format: 'password',
+    minLength: 1,
+  })
   @IsString({ message: 'Password must be a string' })
   @IsNotEmpty({ message: 'Password is required' })
   password!: string;

--- a/apps/api/src/identity/auth/dto/logout.dto.ts
+++ b/apps/api/src/identity/auth/dto/logout.dto.ts
@@ -13,6 +13,7 @@
  * @module LogoutDto
  */
 
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class LogoutDto {
@@ -20,6 +21,10 @@ export class LogoutDto {
    * Refresh token to invalidate
    * Must be a valid JWT
    */
+  @ApiProperty({
+    description: 'Refresh token to invalidate (blacklists both access and refresh tokens)',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   @IsString({ message: 'Refresh token must be a string' })
   @IsNotEmpty({ message: 'Refresh token is required' })
   refreshToken!: string;

--- a/apps/api/src/identity/auth/dto/refresh.dto.ts
+++ b/apps/api/src/identity/auth/dto/refresh.dto.ts
@@ -12,6 +12,7 @@
  * @module RefreshDto
  */
 
+import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString } from 'class-validator';
 
 export class RefreshDto {
@@ -19,6 +20,10 @@ export class RefreshDto {
    * Refresh token from previous authentication
    * Must be a valid JWT with 7-day expiration
    */
+  @ApiProperty({
+    description: 'Refresh token from previous authentication (JWT, 7-day expiration)',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
   @IsString({ message: 'Refresh token must be a string' })
   @IsNotEmpty({ message: 'Refresh token is required' })
   refreshToken!: string;

--- a/apps/api/src/identity/auth/dto/register.dto.ts
+++ b/apps/api/src/identity/auth/dto/register.dto.ts
@@ -9,6 +9,7 @@
  * @module RegisterDto
  */
 
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   IsEmail,
   IsNotEmpty,
@@ -25,6 +26,12 @@ export class RegisterDto {
    * User email - Must be unique within organization
    * Format validation via IsEmail
    */
+  @ApiProperty({
+    description: 'User email address (must be unique)',
+    example: 'jane.smith@company.com',
+    format: 'email',
+    maxLength: 255,
+  })
   @IsEmail({}, { message: 'Invalid email format' })
   @MaxLength(255, { message: 'Email must not exceed 255 characters' })
   email!: string;
@@ -39,6 +46,12 @@ export class RegisterDto {
    * - At least 1 number
    * - At least 1 symbol
    */
+  @ApiProperty({
+    description: 'Strong password (min 8 chars, uppercase, lowercase, number, symbol)',
+    example: 'SecurePass123!',
+    format: 'password',
+    minLength: 8,
+  })
   @IsStrongPassword(
     {
       minLength: 8,
@@ -57,6 +70,12 @@ export class RegisterDto {
   /**
    * User's first name
    */
+  @ApiProperty({
+    description: "User's first name",
+    example: 'Jane',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsString()
   @IsNotEmpty({ message: 'First name is required' })
   @MinLength(1, { message: 'First name must not be empty' })
@@ -66,6 +85,12 @@ export class RegisterDto {
   /**
    * User's last name
    */
+  @ApiProperty({
+    description: "User's last name",
+    example: 'Smith',
+    minLength: 1,
+    maxLength: 100,
+  })
   @IsString()
   @IsNotEmpty({ message: 'Last name is required' })
   @MinLength(1, { message: 'Last name must not be empty' })
@@ -80,6 +105,11 @@ export class RegisterDto {
    *
    * If provided, organization must exist and be ACTIVE.
    */
+  @ApiPropertyOptional({
+    description: 'Organization ID to join (optional - creates new org if omitted)',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    format: 'uuid',
+  })
   @IsOptional()
   @IsUUID(4, { message: 'Invalid organization ID format' })
   organizationId?: string;
@@ -90,6 +120,12 @@ export class RegisterDto {
    * Required if organizationId is not provided.
    * Ignored if organizationId is provided (joining existing org).
    */
+  @ApiPropertyOptional({
+    description: 'Organization name (required if creating new organization)',
+    example: 'Acme Corporation',
+    minLength: 1,
+    maxLength: 200,
+  })
   @IsOptional()
   @IsString()
   @MinLength(1, { message: 'Organization name must not be empty' })

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -101,14 +101,17 @@ async function bootstrap() {
     .build();
 
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  SwaggerModule.setup('api/v1/docs', app, document, {
+    jsonDocumentUrl: 'api/v1/docs-json',
+  });
 
   const port = process.env.PORT || 3001;
   await app.listen(port);
 
   const logger = app.get(Logger);
   logger.log(`🚀 Application is running on: http://localhost:${port}/api`);
-  logger.log(`📚 Swagger docs available at: http://localhost:${port}/api/docs`);
+  logger.log(`📚 Swagger docs available at: http://localhost:${port}/api/v1/docs`);
+  logger.log(`📄 Swagger JSON available at: http://localhost:${port}/api/v1/docs-json`);
 }
 
 bootstrap();

--- a/apps/api/src/proposal/dto/create-proposal.dto.ts
+++ b/apps/api/src/proposal/dto/create-proposal.dto.ts
@@ -7,6 +7,7 @@
  * @module CreateProposalDto
  */
 
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
 
 export class CreateProposalDto {
@@ -16,6 +17,12 @@ export class CreateProposalDto {
    * Required field that describes the proposal.
    * Maximum 500 characters to match database constraint.
    */
+  @ApiProperty({
+    description: 'Proposal title',
+    example: 'Federal IT Modernization RFP Response 2026',
+    minLength: 1,
+    maxLength: 500,
+  })
   @IsString()
   @IsNotEmpty({ message: 'Title is required' })
   @MinLength(1, { message: 'Title must not be empty' })
@@ -28,6 +35,11 @@ export class CreateProposalDto {
    * Helps track which RFP this proposal responds to.
    * Maximum 100 characters to match database constraint.
    */
+  @ApiPropertyOptional({
+    description: 'RFP number from the original RFP document',
+    example: 'RFP-2026-001',
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(100, { message: 'RFP number must not exceed 100 characters' })
@@ -39,6 +51,13 @@ export class CreateProposalDto {
    * Valid statuses: draft, in_progress, completed
    * Note: Status validation is enforced at service layer
    */
+  @ApiPropertyOptional({
+    description: 'Proposal status (defaults to "draft" if not provided)',
+    example: 'draft',
+    enum: ['draft', 'in_progress', 'completed'],
+    default: 'draft',
+    maxLength: 50,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(50, { message: 'Status must not exceed 50 characters' })

--- a/apps/api/src/proposal/dto/update-proposal.dto.ts
+++ b/apps/api/src/proposal/dto/update-proposal.dto.ts
@@ -2,12 +2,12 @@
  * UpdateProposal DTO - Request to update an existing proposal
  *
  * All fields are optional since this is a partial update.
- * Uses PartialType pattern from @nestjs/mapped-types for DRY.
+ * Uses PartialType pattern from @nestjs/swagger for DRY and Swagger documentation.
  *
  * @module UpdateProposalDto
  */
 
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 
 import { CreateProposalDto } from './create-proposal.dto';
 
@@ -16,5 +16,10 @@ import { CreateProposalDto } from './create-proposal.dto';
  *
  * This allows PATCH-style updates where clients can send only
  * the fields they want to modify.
+ *
+ * Using PartialType from @nestjs/swagger ensures that:
+ * - All fields from CreateProposalDto are inherited
+ * - All fields become optional
+ * - Swagger documentation is properly generated
  */
 export class UpdateProposalDto extends PartialType(CreateProposalDto) {}

--- a/apps/api/src/proposal/proposal.controller.ts
+++ b/apps/api/src/proposal/proposal.controller.ts
@@ -21,7 +21,7 @@ import {
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { CurrentUser } from '../identity/auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../identity/auth/guards/jwt-auth.guard';
@@ -40,6 +40,7 @@ interface JwtPayload {
 }
 
 @ApiTags('proposals')
+@ApiBearerAuth()
 @Controller('v1/proposals')
 @UseGuards(JwtAuthGuard)
 export class ProposalController {


### PR DESCRIPTION
## Context
Configurar Swagger UI para documentação automática da API REST do backend, facilitando o Developer Experience e permitindo que desenvolvedores testem endpoints diretamente na interface Swagger.

## Changes
### Configuração Swagger
- ✅ Atualizar rota Swagger de `/api/docs` para `/api/v1/docs`
- ✅ Adicionar endpoint Swagger JSON em `/api/v1/docs-json`
- ✅ Configurar tags: health, identity, proposals, knowledge, agents, export

### Documentação DTOs - Auth Module
- ✅ `LoginDto`: email, password com examples
- ✅ `RegisterDto`: email, password, firstName, lastName, organizationId, organizationName
- ✅ `RefreshDto`: refreshToken
- ✅ `LogoutDto`: refreshToken
- ✅ `AuthResponseDto`: Transformado de interface para classe com UserDto nested
- ✅ Todos com @ApiProperty e examples realistas

### Documentação DTOs - Proposal Module
- ✅ `CreateProposalDto`: title, rfpNumber, status
- ✅ `UpdateProposalDto`: PartialType do CreateProposalDto (usando @nestjs/swagger)
- ✅ `QueryProposalDto`: Já estava documentado

### Documentação Controllers
- ✅ **AuthController**: @ApiTags('identity'), 4 endpoints com @ApiOperation e @ApiResponse
  - POST /v1/auth/register (201, 400, 404, 409, 429)
  - POST /v1/auth/login (200, 400, 401, 429)
  - POST /v1/auth/refresh (200, 400, 401, 429)
  - POST /v1/auth/logout (204, 400, 401, 429) com @ApiBearerAuth
- ✅ **ProposalController**: @ApiTags('proposals'), @ApiBearerAuth, 5 endpoints documentados
  - POST /v1/proposals (201, 400, 401)
  - GET /v1/proposals (200, 401) com query filters
  - GET /v1/proposals/:id (200, 401, 404)
  - PUT /v1/proposals/:id (200, 400, 401, 404)
  - DELETE /v1/proposals/:id (204, 401, 404)

## Testing
✅ **Compilation**: TypeScript compilou sem erros
✅ **Server Start**: Servidor iniciou com sucesso em http://localhost:3001
✅ **Swagger UI**: Acessível em http://localhost:3001/api/v1/docs
✅ **Swagger JSON**: Exportável em http://localhost:3001/api/v1/docs-json
✅ **Schema Validation**: Todos os schemas gerados com properties, examples e enums
✅ **Bearer Auth**: Documentado em endpoints protegidos
✅ **Try it out**: Examples funcionais para teste interativo

## Acceptance Criteria
- [x] @nestjs/swagger instalado
- [x] Swagger UI acessível em /api/v1/docs
- [x] Todos os endpoints documentados (9 endpoints)
- [x] DTOs têm @ApiProperty com examples
- [x] Controllers têm @ApiTags e @ApiOperation
- [x] Authentication documentada (Bearer token)
- [x] Responses documentadas (@ApiResponse)
- [x] Swagger JSON exportável em /api/v1/docs-json
- [x] Examples funcionais (try it out)

## Screenshots
### Swagger UI
```
🚀 Application is running on: http://localhost:3001/api
📚 Swagger docs available at: http://localhost:3001/api/v1/docs
📄 Swagger JSON available at: http://localhost:3001/api/v1/docs-json
```

### Endpoints Documentados
- 1 Health endpoint
- 4 Auth endpoints (identity)
- 8 Organization endpoints (identity)
- 5 Proposal endpoints (proposals)
- 1 Dashboard endpoint

Total: **19 endpoints** com documentação completa Swagger

## Risks
Nenhum risco identificado. Mudanças são puramente de documentação (decorators) e não afetam lógica de negócio.

## Rollback Plan
Reverter commit e remover decorators Swagger dos DTOs e controllers. A aplicação continuará funcionando normalmente sem documentação.

## Closes
Closes #126