### PR TITLE
[#202] Implement Presigned Upload URLs for R2

### DIFF
--- a/apps/api/src/storage/r2.service.spec.ts
+++ b/apps/api/src/storage/r2.service.spec.ts
@@ -159,8 +159,8 @@ describe('R2Service', () => {
     });
   });
 
-  describe('presigned URLs (not implemented yet)', () => {
-    it('should throw error for generatePresignedUploadUrl when not initialized', async () => {
+  describe('generatePresignedUploadUrl', () => {
+    it('should throw error when not initialized', async () => {
       const params = {
         organizationId: 'org_123',
         documentId: 'doc_456',
@@ -173,7 +173,7 @@ describe('R2Service', () => {
       );
     });
 
-    it('should throw "not implemented" error for generatePresignedUploadUrl after initialization', async () => {
+    it('should generate presigned URL with correct parameters', async () => {
       await service.initialize();
 
       const params = {
@@ -183,12 +183,152 @@ describe('R2Service', () => {
         contentType: 'application/pdf',
       };
 
+      const result = await service.generatePresignedUploadUrl(params);
+
+      // Verify result structure
+      expect(result).toHaveProperty('url');
+      expect(result).toHaveProperty('key');
+      expect(result).toHaveProperty('expiresAt');
+
+      // Verify key format: {org_id}/documents/{doc_id}/original.{ext}
+      expect(result.key).toBe('org_123/documents/doc_456/original.pdf');
+
+      // Verify URL is a valid URL
+      expect(() => new URL(result.url)).not.toThrow();
+
+      // Verify expiresAt is a valid ISO 8601 timestamp
+      expect(() => new Date(result.expiresAt)).not.toThrow();
+      expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('should use default expiration of 15 minutes (900 seconds)', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: 'org_123',
+        documentId: 'doc_456',
+        extension: 'pdf',
+        contentType: 'application/pdf',
+      };
+
+      const beforeCall = Date.now();
+      const result = await service.generatePresignedUploadUrl(params);
+      const afterCall = Date.now();
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedMinExpiry = beforeCall + 900 * 1000; // 15 minutes
+      const expectedMaxExpiry = afterCall + 900 * 1000;
+
+      expect(expiresAt).toBeGreaterThanOrEqual(expectedMinExpiry);
+      expect(expiresAt).toBeLessThanOrEqual(expectedMaxExpiry);
+    });
+
+    it('should use custom expiration when provided', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: 'org_123',
+        documentId: 'doc_456',
+        extension: 'pdf',
+        contentType: 'application/pdf',
+        options: {
+          expiresIn: 600, // 10 minutes
+        },
+      };
+
+      const beforeCall = Date.now();
+      const result = await service.generatePresignedUploadUrl(params);
+      const afterCall = Date.now();
+
+      const expiresAt = new Date(result.expiresAt).getTime();
+      const expectedMinExpiry = beforeCall + 600 * 1000; // 10 minutes
+      const expectedMaxExpiry = afterCall + 600 * 1000;
+
+      expect(expiresAt).toBeGreaterThanOrEqual(expectedMinExpiry);
+      expect(expiresAt).toBeLessThanOrEqual(expectedMaxExpiry);
+    });
+
+    it('should handle different file extensions', async () => {
+      await service.initialize();
+
+      const extensions = ['pdf', 'docx', 'xlsx', 'png', 'jpg'];
+
+      for (const ext of extensions) {
+        const params = {
+          organizationId: 'org_123',
+          documentId: 'doc_456',
+          extension: ext,
+          contentType: 'application/octet-stream',
+        };
+
+        const result = await service.generatePresignedUploadUrl(params);
+        expect(result.key).toBe(`org_123/documents/doc_456/original.${ext}`);
+      }
+    });
+
+    it('should throw error if organizationId is missing', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: '',
+        documentId: 'doc_456',
+        extension: 'pdf',
+        contentType: 'application/pdf',
+      };
+
       await expect(service.generatePresignedUploadUrl(params)).rejects.toThrow(
-        'Not implemented yet - see issue #202',
+        'organizationId is required',
       );
     });
 
-    it('should throw error for generatePresignedDownloadUrl when not initialized', async () => {
+    it('should throw error if documentId is missing', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: 'org_123',
+        documentId: '',
+        extension: 'pdf',
+        contentType: 'application/pdf',
+      };
+
+      await expect(service.generatePresignedUploadUrl(params)).rejects.toThrow(
+        'documentId is required',
+      );
+    });
+
+    it('should throw error if extension is missing', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: 'org_123',
+        documentId: 'doc_456',
+        extension: '',
+        contentType: 'application/pdf',
+      };
+
+      await expect(service.generatePresignedUploadUrl(params)).rejects.toThrow(
+        'extension is required',
+      );
+    });
+
+    it('should throw error if contentType is missing', async () => {
+      await service.initialize();
+
+      const params = {
+        organizationId: 'org_123',
+        documentId: 'doc_456',
+        extension: 'pdf',
+        contentType: '',
+      };
+
+      await expect(service.generatePresignedUploadUrl(params)).rejects.toThrow(
+        'contentType is required',
+      );
+    });
+  });
+
+  describe('generatePresignedDownloadUrl (not implemented yet)', () => {
+    it('should throw error when not initialized', async () => {
       const params = {
         organizationId: 'org_123',
         documentId: 'doc_456',
@@ -201,7 +341,7 @@ describe('R2Service', () => {
       );
     });
 
-    it('should throw "not implemented" error for generatePresignedDownloadUrl after initialization', async () => {
+    it('should throw "not implemented" error after initialization', async () => {
       await service.initialize();
 
       const params = {

--- a/apps/api/src/storage/r2.service.ts
+++ b/apps/api/src/storage/r2.service.ts
@@ -7,7 +7,8 @@
  * @module R2Service
  */
 
-import { S3Client } from '@aws-sdk/client-s3';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
@@ -130,10 +131,49 @@ export class R2Service implements IStorageService, OnModuleInit {
    * // Returns: { url: 'https://...', key: 'org_123/documents/doc_456/original.pdf', expiresAt: '...' }
    * ```
    */
-  async generatePresignedUploadUrl(_params: UploadUrlParams): Promise<PresignedUrlResult> {
+  async generatePresignedUploadUrl(params: UploadUrlParams): Promise<PresignedUrlResult> {
     this.ensureInitialized();
-    // Implementation will be added in sub-issue #202
-    throw new Error('Not implemented yet - see issue #202');
+
+    // Validate required parameters
+    if (!params.organizationId) {
+      throw new Error('organizationId is required');
+    }
+    if (!params.documentId) {
+      throw new Error('documentId is required');
+    }
+    if (!params.extension) {
+      throw new Error('extension is required');
+    }
+    if (!params.contentType) {
+      throw new Error('contentType is required');
+    }
+
+    // Construct object key: {org_id}/documents/{doc_id}/original.{ext}
+    const key = `${params.organizationId}/documents/${params.documentId}/original.${params.extension}`;
+
+    // Default expiration: 15 minutes (900 seconds)
+    const expiresIn = params.options?.expiresIn ?? 900;
+
+    // Create PutObjectCommand with content type
+    const command = new PutObjectCommand({
+      Bucket: this.config.bucketName,
+      Key: key,
+      ContentType: params.contentType,
+    });
+
+    // Generate presigned URL
+    const url = await getSignedUrl(this.s3Client, command, { expiresIn });
+
+    // Calculate expiration timestamp
+    const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+
+    this.logger.debug(`Generated presigned upload URL for key: ${key}, expires at: ${expiresAt}`);
+
+    return {
+      url,
+      key,
+      expiresAt,
+    };
   }
 
   /**


### PR DESCRIPTION
## Context
This PR implements presigned upload URL generation for Cloudflare R2 storage, enabling direct client-to-storage uploads without exposing credentials.

This is sub-issue 2/5 of parent issue #26 (Cloudflare R2 Integration).

## Changes
- Added `PutObjectCommand` and `getSignedUrl` imports from AWS SDK
- Implemented `generatePresignedUploadUrl()` method in R2Service
- Added parameter validation for all required fields:
  - `organizationId` (required)
  - `documentId` (required)
  - `extension` (required)
  - `contentType` (required)
- Constructed object key pattern: `{org_id}/documents/{doc_id}/original.{ext}`
- Default expiration: 15 minutes (900 seconds)
- Support for custom expiration via `options.expiresIn`
- Comprehensive unit tests (8 new tests for generatePresignedUploadUrl)

## Testing
- [x] All unit tests passing (24 total tests for R2Service)
- [x] All API tests passing (228 total tests)
- [x] TypeScript type checking passed
- [x] Parameter validation tested (organizationId, documentId, extension, contentType)
- [x] Default expiration (15 minutes) validated
- [x] Custom expiration option tested
- [x] Multiple file extensions tested (pdf, docx, xlsx, png, jpg)
- [x] Error handling for missing parameters tested
- [x] Uninitialized service error tested

**Test Results:**
```
Test Suites: 16 passed, 16 total
Tests:       228 passed, 228 total
```

## Risks
- None - This is a pure addition with comprehensive tests
- Existing functionality remains unchanged
- Download URL implementation still pending (issue #203)

## Rollback Plan
- Revert this commit if issues arise
- Service gracefully degrades if R2 is not configured (logs warning)
- `ensureInitialized()` check prevents usage before proper setup

## Acceptance Criteria (from #202)
- [x] Método `generatePresignedUploadUrl()` implementado
- [x] URLs expiram em 15 minutos
- [x] Path inclui organization_id e document_id
- [x] Content-Type configurável
- [x] Testes unitários passando (mock S3Client)
- [x] Validação de parâmetros obrigatórios

## Next Steps
After this PR merges, the next issues in the R2 sequence are:
- #203: [R2-26c] Implement Presigned Download URLs
- #204: [R2-26d] Implement Streaming Upload for Large Files
- #205: [R2-26e] Configure CORS & Lifecycle Rules

## Closes
Closes #202