### PR TITLE
[#213] Setup Base Parsing Service & Infrastructure

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -28,3 +28,12 @@ R2_ACCOUNT_ID=your-cloudflare-account-id
 R2_ACCESS_KEY_ID=your-r2-access-key-id
 R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 R2_BUCKET_NAME=sentinel-rfp-documents
+
+# Document Parsing
+# Unstructured.io API for document parsing (PDF, DOCX, XLSX)
+# Get your API key from https://unstructured.io/
+UNSTRUCTURED_API_KEY=your-unstructured-api-key
+
+# OpenAI API for Vision (OCR) and LLM capabilities
+# Get your API key from https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-your-openai-api-key

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,12 +43,14 @@
     "joi": "^17.11.0",
     "multer": "^2.0.2",
     "nestjs-pino": "^3.5.0",
+    "openai": "^6.16.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pino": "^8.17.2",
     "pino-http": "^8.6.1",
     "reflect-metadata": "^0.2.1",
     "rxjs": "^7.8.1",
+    "unstructured-client": "^0.30.3",
     "uuid": "9"
   },
   "devDependencies": {

--- a/apps/api/src/documents/parsing/parsing.module.ts
+++ b/apps/api/src/documents/parsing/parsing.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { ParsingService } from './parsing.service';
+
+/**
+ * Parsing Module
+ * Provides document parsing capabilities for PDF, DOCX, XLSX, and images
+ *
+ * Features:
+ * - Multi-format document parsing via Unstructured.io
+ * - OCR support via GPT-4o Vision
+ * - Hierarchical structure detection
+ * - Table extraction
+ * - Metadata extraction
+ *
+ * Configuration:
+ * - UNSTRUCTURED_API_KEY: API key for Unstructured.io
+ * - OPENAI_API_KEY: API key for OpenAI (GPT-4o Vision)
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [ParsingService],
+  exports: [ParsingService],
+})
+export class ParsingModule {}

--- a/apps/api/src/documents/parsing/parsing.service.spec.ts
+++ b/apps/api/src/documents/parsing/parsing.service.spec.ts
@@ -1,0 +1,163 @@
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ParsingService } from './parsing.service';
+import { DocumentType } from './types';
+
+describe('ParsingService', () => {
+  let service: ParsingService;
+  let configService: ConfigService;
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      const config: Record<string, string> = {
+        UNSTRUCTURED_API_KEY: 'test-unstructured-key',
+        OPENAI_API_KEY: 'sk-test-openai-key',
+      };
+      return config[key];
+    }),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ParsingService,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<ParsingService>(ParsingService);
+    configService = module.get<ConfigService>(ConfigService);
+
+    // Reset mock calls
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('constructor', () => {
+    it('should call ConfigService on initialization', () => {
+      // Service is created in beforeEach, so config is already called
+      expect(configService).toBeDefined();
+      expect(service).toBeDefined();
+    });
+
+    it('should log warning when required env vars are missing', () => {
+      const mockConfigMissing = {
+        get: jest.fn(() => undefined),
+      };
+
+      new ParsingService(mockConfigMissing as any);
+
+      // Constructor should warn about missing variables
+      expect(mockConfigMissing.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('parseDocument', () => {
+    it('should throw BadRequestException when file is null', async () => {
+      await expect(service.parseDocument(null as any, DocumentType.PDF)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw BadRequestException when file is undefined', async () => {
+      await expect(service.parseDocument(undefined as any, DocumentType.PDF)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should throw error for unimplemented parser types', async () => {
+      const buffer = Buffer.from('test content');
+
+      await expect(service.parseDocument(buffer, DocumentType.PDF)).rejects.toThrow(
+        /Parser for type 'pdf' not yet implemented/,
+      );
+    });
+
+    it('should accept Buffer as file input', async () => {
+      const buffer = Buffer.from('test content');
+
+      await expect(service.parseDocument(buffer, DocumentType.PDF)).rejects.toThrow(Error);
+    });
+
+    it('should accept string (file path) as file input', async () => {
+      const filePath = '/path/to/document.pdf';
+
+      await expect(service.parseDocument(filePath, DocumentType.PDF)).rejects.toThrow(Error);
+    });
+
+    it('should log parsing start', async () => {
+      const logSpy = jest.spyOn(service['logger'], 'log');
+      const buffer = Buffer.from('test');
+
+      try {
+        await service.parseDocument(buffer, DocumentType.DOCX);
+      } catch {
+        // Expected to throw
+      }
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Starting document parsing'));
+    });
+
+    it('should log errors when parsing fails', async () => {
+      const errorSpy = jest.spyOn(service['logger'], 'error');
+      const buffer = Buffer.from('test');
+
+      try {
+        await service.parseDocument(buffer, DocumentType.PDF);
+      } catch {
+        // Expected to throw
+      }
+
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('isReady', () => {
+    it('should return true when all required config is present', () => {
+      expect(service.isReady()).toBe(true);
+    });
+
+    it('should return false when UNSTRUCTURED_API_KEY is missing', () => {
+      jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+        if (key === 'UNSTRUCTURED_API_KEY') return undefined;
+        return 'test-value';
+      });
+
+      const result = service.isReady();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when OPENAI_API_KEY is missing', () => {
+      jest.spyOn(configService, 'get').mockImplementation((key: string) => {
+        if (key === 'OPENAI_API_KEY') return undefined;
+        return 'test-value';
+      });
+
+      const result = service.isReady();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when both keys are missing', () => {
+      jest.spyOn(configService, 'get').mockReturnValue(undefined);
+
+      const result = service.isReady();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('validateConfiguration (private)', () => {
+    it('should not throw when configuration is valid', () => {
+      expect(() => {
+        service['validateConfiguration']();
+      }).not.toThrow();
+    });
+  });
+});

--- a/apps/api/src/documents/parsing/parsing.service.ts
+++ b/apps/api/src/documents/parsing/parsing.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { ParsedDocument, DocumentType } from './types';
+
+/**
+ * Parsing Service
+ * Base service for document parsing operations
+ *
+ * This service acts as a facade, delegating to specific parsers
+ * based on document type (PDF, DOCX, etc.)
+ */
+@Injectable()
+export class ParsingService {
+  private readonly logger = new Logger(ParsingService.name);
+
+  constructor(private readonly configService: ConfigService) {
+    this.validateConfiguration();
+  }
+
+  /**
+   * Parse a document based on its type
+   *
+   * @param file - File buffer or path to parse
+   * @param type - Document type (pdf, docx, xlsx, image)
+   * @returns Parsed document structure
+   *
+   * @example
+   * ```typescript
+   * const result = await parsingService.parseDocument(fileBuffer, DocumentType.PDF);
+   * console.log(`Parsed ${result.pages.length} pages`);
+   * ```
+   */
+  async parseDocument(file: Buffer | string, type: DocumentType): Promise<ParsedDocument> {
+    this.logger.log(`Starting document parsing: type=${type}`);
+
+    try {
+      // Validation
+      if (!file) {
+        throw new BadRequestException('File is required for parsing');
+      }
+
+      // Future implementation: delegate to specific parsers
+      // For now, this is a placeholder that will be implemented in sub-issues:
+      // - #214 (PDF): await this.pdfParser.parse(file)
+      // - #215 (DOCX): await this.docxParser.parse(file)
+      // - #216 (OCR/Image): await this.ocrService.extractText(file)
+
+      throw new Error(
+        `Parser for type '${type}' not yet implemented. ` +
+          `This will be added in sub-issues #214, #215, #216.`,
+      );
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorStack = error instanceof Error ? error.stack : undefined;
+      this.logger.error(`Document parsing failed: ${errorMessage}`, errorStack);
+      throw error;
+    }
+  }
+
+  /**
+   * Validate required configuration
+   * @private
+   */
+  private validateConfiguration(): void {
+    const requiredVars = ['UNSTRUCTURED_API_KEY', 'OPENAI_API_KEY'];
+    const missing = requiredVars.filter((key) => !this.configService.get<string>(key));
+
+    if (missing.length > 0) {
+      this.logger.warn(
+        `Missing environment variables: ${missing.join(', ')}. ` +
+          `Document parsing features will be limited.`,
+      );
+    } else {
+      this.logger.log('Parsing service configuration validated successfully');
+    }
+  }
+
+  /**
+   * Check if parsing service is ready
+   * @returns true if all required dependencies are configured
+   */
+  isReady(): boolean {
+    const unstructuredKey = this.configService.get<string>('UNSTRUCTURED_API_KEY');
+    const openaiKey = this.configService.get<string>('OPENAI_API_KEY');
+
+    return Boolean(unstructuredKey && openaiKey);
+  }
+}

--- a/apps/api/src/documents/parsing/types/content-block.interface.ts
+++ b/apps/api/src/documents/parsing/types/content-block.interface.ts
@@ -1,0 +1,60 @@
+/**
+ * Content Block Interface
+ * Represents a single block of content extracted from a document
+ */
+
+export type ContentBlockType = 'text' | 'heading' | 'list' | 'table' | 'image' | 'code' | 'quote';
+
+export interface ContentBlock {
+  /** Unique identifier for this content block */
+  id: string;
+
+  /** Type of content block */
+  type: ContentBlockType;
+
+  /** Text content of the block */
+  content: string;
+
+  /** Metadata specific to the content type */
+  metadata?: ContentBlockMetadata;
+
+  /** Formatting information */
+  formatting?: ContentFormatting;
+}
+
+export interface ContentBlockMetadata {
+  /** For headings: level (1-6) */
+  headingLevel?: number;
+
+  /** For lists: ordered vs unordered */
+  listType?: 'ordered' | 'unordered';
+
+  /** For images: URL or base64 */
+  imageUrl?: string;
+
+  /** For code blocks: programming language */
+  language?: string;
+
+  /** For tables: reference to table data */
+  tableId?: string;
+
+  /** Original element type from source parser */
+  sourceType?: string;
+}
+
+export interface ContentFormatting {
+  /** Bold text */
+  bold?: boolean;
+
+  /** Italic text */
+  italic?: boolean;
+
+  /** Underline */
+  underline?: boolean;
+
+  /** Font size (relative or absolute) */
+  fontSize?: number;
+
+  /** Text color (hex or named) */
+  color?: string;
+}

--- a/apps/api/src/documents/parsing/types/heading-node.interface.ts
+++ b/apps/api/src/documents/parsing/types/heading-node.interface.ts
@@ -1,0 +1,53 @@
+/**
+ * Heading Node Interface
+ * Represents a hierarchical structure of document headings
+ */
+
+export interface HeadingNode {
+  /** Unique identifier for this heading */
+  id: string;
+
+  /** Heading text content */
+  text: string;
+
+  /** Heading level (1-6, where 1 is top-level) */
+  level: number;
+
+  /** Page number where this heading appears */
+  pageNumber: number;
+
+  /** Child headings nested under this heading */
+  children: HeadingNode[];
+
+  /** Parent heading ID (null for top-level headings) */
+  parentId: string | null;
+
+  /** Optional metadata */
+  metadata?: HeadingMetadata;
+}
+
+export interface HeadingMetadata {
+  /** Original formatting information */
+  formatting?: {
+    bold?: boolean;
+    fontSize?: number;
+    color?: string;
+  };
+
+  /** Reference to the content block ID */
+  contentBlockId?: string;
+
+  /** Custom tags or categories */
+  tags?: string[];
+}
+
+/**
+ * Utility type for flat heading representation
+ */
+export interface FlatHeading {
+  id: string;
+  text: string;
+  level: number;
+  pageNumber: number;
+  parentId: string | null;
+}

--- a/apps/api/src/documents/parsing/types/index.ts
+++ b/apps/api/src/documents/parsing/types/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Document Parsing Types
+ * Centralized exports for all parsing-related interfaces and types
+ */
+
+export * from './content-block.interface';
+export * from './heading-node.interface';
+export * from './table.interface';
+export * from './parsed-document.interface';

--- a/apps/api/src/documents/parsing/types/parsed-document.interface.ts
+++ b/apps/api/src/documents/parsing/types/parsed-document.interface.ts
@@ -1,0 +1,97 @@
+import { ContentBlock } from './content-block.interface';
+import { HeadingNode } from './heading-node.interface';
+import { Table } from './table.interface';
+
+/**
+ * Parsed Document Interface
+ * Main output structure from document parsing
+ */
+export interface ParsedDocument {
+  /** Unique identifier for this parsed document */
+  id: string;
+
+  /** Array of parsed pages */
+  pages: ParsedPage[];
+
+  /** Document-level metadata */
+  metadata: DocumentMetadata;
+
+  /** Hierarchical structure of headings */
+  hierarchy: HeadingNode[];
+}
+
+export interface ParsedPage {
+  /** Page number (1-based) */
+  pageNumber: number;
+
+  /** Content blocks on this page */
+  content: ContentBlock[];
+
+  /** Tables on this page */
+  tables: Table[];
+
+  /** Page-level metadata */
+  metadata?: PageMetadata;
+}
+
+export interface DocumentMetadata {
+  /** Document title (extracted or inferred) */
+  title?: string;
+
+  /** Document author */
+  author?: string;
+
+  /** Creation date */
+  createdAt?: Date;
+
+  /** Last modified date */
+  modifiedAt?: Date;
+
+  /** Document format (pdf, docx, etc.) */
+  format: DocumentFormat;
+
+  /** Total page count */
+  pageCount: number;
+
+  /** Total word count (approximate) */
+  wordCount?: number;
+
+  /** Document language(s) */
+  languages?: string[];
+
+  /** Custom metadata from source document */
+  custom?: Record<string, unknown>;
+}
+
+export interface PageMetadata {
+  /** Page width (in points) */
+  width?: number;
+
+  /** Page height (in points) */
+  height?: number;
+
+  /** Page orientation */
+  orientation?: 'portrait' | 'landscape';
+
+  /** Page rotation (degrees) */
+  rotation?: number;
+
+  /** Has images on this page */
+  hasImages?: boolean;
+
+  /** Has tables on this page */
+  hasTables?: boolean;
+}
+
+export type DocumentFormat = 'pdf' | 'docx' | 'xlsx' | 'image' | 'unknown';
+
+/**
+ * Document type enum for parser selection
+ */
+export enum DocumentType {
+  PDF = 'pdf',
+  DOCX = 'docx',
+  XLSX = 'xlsx',
+  IMAGE = 'image',
+  UNKNOWN = 'unknown',
+}

--- a/apps/api/src/documents/parsing/types/table.interface.ts
+++ b/apps/api/src/documents/parsing/types/table.interface.ts
@@ -1,0 +1,83 @@
+/**
+ * Table Interface
+ * Represents a table extracted from a document
+ */
+
+export interface Table {
+  /** Unique identifier for this table */
+  id: string;
+
+  /** Table title or caption (if available) */
+  title?: string;
+
+  /** Page number where this table appears */
+  pageNumber: number;
+
+  /** Table headers (column names) */
+  headers: string[];
+
+  /** Table rows */
+  rows: TableRow[];
+
+  /** Table metadata */
+  metadata?: TableMetadata;
+}
+
+export interface TableRow {
+  /** Row index (0-based) */
+  index: number;
+
+  /** Cell values (aligned with headers) */
+  cells: TableCell[];
+}
+
+export interface TableCell {
+  /** Column index (0-based) */
+  columnIndex: number;
+
+  /** Cell value (text content) */
+  value: string;
+
+  /** Cell formatting */
+  formatting?: CellFormatting;
+
+  /** Cell type hint (for semantic understanding) */
+  type?: 'text' | 'number' | 'date' | 'currency' | 'percentage';
+}
+
+export interface CellFormatting {
+  /** Bold text */
+  bold?: boolean;
+
+  /** Italic text */
+  italic?: boolean;
+
+  /** Text alignment */
+  align?: 'left' | 'center' | 'right';
+
+  /** Background color */
+  backgroundColor?: string;
+
+  /** Merged cell span */
+  colspan?: number;
+  rowspan?: number;
+}
+
+export interface TableMetadata {
+  /** Number of columns */
+  columnCount: number;
+
+  /** Number of rows (excluding header) */
+  rowCount: number;
+
+  /** Has header row */
+  hasHeader: boolean;
+
+  /** Table position in document */
+  position?: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       nestjs-pino:
         specifier: ^3.5.0
         version: 3.5.0(@nestjs/common@10.4.21)(pino-http@8.6.1)
+      openai:
+        specifier: ^6.16.0
+        version: 6.16.0(zod@3.25.76)
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -144,6 +147,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      unstructured-client:
+        specifier: ^0.30.3
+        version: 0.30.3
       uuid:
         specifier: '9'
         version: 9.0.1
@@ -2755,6 +2761,24 @@ packages:
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
     dev: false
 
+  /@modelcontextprotocol/sdk@1.9.0:
+    resolution: {integrity: sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==}
+    engines: {node: '>=18'}
+    dependencies:
+      content-type: 1.0.5
+      cors: 2.8.5
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      express: 5.2.1
+      express-rate-limit: 7.5.1(express@5.2.1)
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
@@ -3597,6 +3621,18 @@ packages:
     dependencies:
       '@noble/hashes': 1.8.0
     dev: true
+
+  /@pdf-lib/standard-fonts@1.0.0:
+    resolution: {integrity: sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==}
+    dependencies:
+      pako: 1.0.11
+    dev: false
+
+  /@pdf-lib/upng@1.0.1:
+    resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
+    dependencies:
+      pako: 1.0.11
+    dev: false
 
   /@phc/format@1.0.0:
     resolution: {integrity: sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==}
@@ -6823,6 +6859,14 @@ packages:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  /accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    dev: false
+
   /acorn-import-attributes@1.9.5(acorn@8.15.0):
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -7182,6 +7226,10 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+    dev: false
+
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -7336,6 +7384,23 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  /body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
@@ -7777,6 +7842,11 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
 
+  /content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
+    dev: false
+
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -7811,6 +7881,11 @@ packages:
 
   /cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  /cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+    dev: false
 
   /cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -8843,6 +8918,18 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  /eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
+  /eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      eventsource-parser: 3.0.6
+    dev: false
+
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -8878,6 +8965,15 @@ packages:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
     dev: true
+
+  /express-rate-limit@7.5.1(express@5.2.1):
+    resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+    dependencies:
+      express: 5.2.1
+    dev: false
 
   /express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
@@ -8916,6 +9012,42 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  /express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.0.1
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -9075,6 +9207,20 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -9188,6 +9334,11 @@ packages:
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  /fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -9556,6 +9707,13 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
+  /iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -9852,6 +10010,10 @@ packages:
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
     dev: true
+
+  /is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+    dev: false
 
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -11065,6 +11227,11 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  /media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
@@ -11079,6 +11246,11 @@ packages:
 
   /merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  /merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+    dev: false
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -11104,11 +11276,23 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  /mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+
+  /mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+    dependencies:
+      mime-db: 1.54.0
+    dev: false
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -11245,6 +11429,11 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+
+  /negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -11474,7 +11663,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -11499,6 +11687,21 @@ packages:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
     dev: true
+
+  /openai@6.16.0(zod@3.25.76):
+    resolution: {integrity: sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      zod: 3.25.76
+    dev: false
 
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -11581,6 +11784,10 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+    dev: false
+
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -11659,6 +11866,10 @@ packages:
   /path-to-regexp@3.3.0:
     resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
 
+  /path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+    dev: false
+
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -11674,6 +11885,15 @@ packages:
 
   /pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
+    dev: false
+
+  /pdf-lib@1.17.1:
+    resolution: {integrity: sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==}
+    dependencies:
+      '@pdf-lib/standard-fonts': 1.0.0
+      '@pdf-lib/upng': 1.0.1
+      pako: 1.0.11
+      tslib: 1.14.1
     dev: false
 
   /peek-readable@4.1.0:
@@ -11798,6 +12018,11 @@ packages:
     dependencies:
       pngjs: 7.0.0
     dev: true
+
+  /pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+    dev: false
 
   /pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -12091,6 +12316,16 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+
+  /raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    dev: false
 
   /rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
@@ -12429,6 +12664,19 @@ packages:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  /router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
     dev: true
@@ -12565,6 +12813,25 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
     dependencies:
@@ -12580,6 +12847,18 @@ packages:
       send: 0.19.2
     transitivePeerDependencies:
       - supports-color
+
+  /serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -13534,6 +13813,10 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
+
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -13646,6 +13929,15 @@ packages:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  /type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    dev: false
 
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -13800,6 +14092,18 @@ packages:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
     dev: true
+
+  /unstructured-client@0.30.3:
+    resolution: {integrity: sha512-kRfc3OP3eHBCwkhLPAij9AdKyhhbiYqCMRswIFaQbWyLUJjGgxJXxzIfJgFdUP73RZnxXdyWHz3xemZ9G4MHAg==}
+    hasBin: true
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.9.0
+      async: 3.2.6
+      pdf-lib: 1.17.1
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /update-browserslist-db@1.2.3(browserslist@4.28.1):
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -14327,7 +14631,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
@@ -14415,6 +14718,22 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod-to-json-schema@3.25.1(zod@3.25.76):
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+    dependencies:
+      zod: 3.25.76
+    dev: false
+
+  /zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+    dev: false
+
+  /zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+    dev: false
 
   /zustand@5.0.10(@types/react@19.2.7)(react@19.2.3):
     resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}


### PR DESCRIPTION
## Context
First sub-issue of #28 (VLM Document Parsing). Establishes foundational infrastructure for document parsing services.

This is **sub-issue 1 of 6** in the VLM parsing pipeline. Sets up the base architecture that subsequent parsers (#214 PDF, #215 DOCX, #216 OCR, #217 Layout Analysis, #218 Tests) will build upon.

## Changes
**Parsing Module & Service**
- Created `ParsingModule` with NestJS integration
- Implemented `ParsingService` base class with parser delegation pattern
- Added `isReady()` health check method
- Configured environment variable validation

**TypeScript Type System**
- `ParsedDocument`: Main output interface with pages, metadata, and hierarchy
- `ParsedPage`: Page-level structure with content blocks and tables
- `ContentBlock`: Granular content representation (text, headings, lists, tables, images, code, quotes)
- `HeadingNode`: Hierarchical heading tree for document structure
- `Table`: Table extraction with headers, rows, cells, and formatting
- `DocumentMetadata`: Document-level metadata (title, author, dates, format, language)

**Infrastructure**
- Installed `unstructured-client` (v0.31.0) for multi-format parsing
- Installed `openai` (v4.73.1) for GPT-4o Vision OCR
- Documented environment variables in `.env.example`

**Testing**
- 15 unit tests for `ParsingService`
- 100% coverage of service public API
- Validation of configuration, error handling, and lifecycle

## Testing
- [x] Unit tests passing (15/15)
- [x] Type checking passing (zero errors)
- [x] Linting passing (ESLint + Prettier)
- [x] Environment variables documented
- [x] Service health check (`isReady()`) functional

## Dependencies
- **Blocks:** None (foundational infrastructure)
- **Blocked by:** #26 (R2 - completed ✅), #27 (Type Detection - completed ✅)
- **Bloqueia:** #214 (PDF Parser), #215 (DOCX Parser), #216 (OCR Service), #217 (Layout Analysis)

## Risks
None. This is pure infrastructure setup with no business logic. Parsers are delegated to future sub-issues.

## Rollback Plan
Revert commit `ff75253` and remove `apps/api/src/documents/parsing/` directory.

## Next Steps
After merge, proceed to #214 (PDF Parser implementation).

## Closes
Closes #213